### PR TITLE
Fix rounded speaker pictures at speaker info view

### DIFF
--- a/src/views/speakers/SpeakerInfo.vue
+++ b/src/views/speakers/SpeakerInfo.vue
@@ -1,6 +1,8 @@
 <template>
   <div @click="gotoSpeaker(item.id)">
-    <img v-bind:src="item.imageUrl" v-bind:alt="altText" />
+    <div class="speaker-picture">
+      <img v-bind:src="item.imageUrl" v-bind:alt="altText" />
+    </div>
     <h4 data-cy="name">{{ item.name }}</h4>
   </div>
 </template>
@@ -27,15 +29,24 @@ export default class SpeakerInfo extends Vue {
 <style lang="scss" scoped>
 .group {
   .item {
-    grid-template-columns: 2.5em auto;
+    grid-template-columns: 3.5em auto;
     padding-left: var(--padding);
 
-    img {
+    .speaker-picture {
       grid-column-start: 1;
       grid-row-start: 1;
-      height: 2.3rem;
-      border-radius: 50%;
       margin-bottom: var(--padding);
+      border-radius: 50%;
+      overflow: hidden;
+      width: 45px;
+      height: 45px;
+    }
+
+    .speaker-picture img {
+      display: block;
+      width: 100%;
+      object-fit: cover;
+      margin: auto;
     }
   }
 }


### PR DESCRIPTION
Eine Änderung kosmetischer Art, welche die Eierköpfe der Speaker Info Seite behebt.

**Before**
![localhost_8080_speakers 1](https://user-images.githubusercontent.com/658431/50865019-34a05d80-13a4-11e9-8019-a1923df2dc8c.png)

**After**
![localhost_8080_speakers](https://user-images.githubusercontent.com/658431/50865025-379b4e00-13a4-11e9-982b-b579f9624d47.png)
